### PR TITLE
Add content-services as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 	}
 	],
 	"require": {
-		"aws/aws-sdk-php": "*"
+		"aws/aws-sdk-php": "*",
+		"silverstripe/content-services": "*"
 	}
 }


### PR DESCRIPTION
It appears that this module is useless without the content-services module; we should enlist Composer's help in that regard.
